### PR TITLE
feat(blog): prerender year & tag archives so /blog ships posts in HTML

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -61,4 +61,16 @@ export default tseslint.config(
       ...reactHooks.configs.recommended.rules,
     },
   },
+  // Cloudflare Pages Functions run in the Workers runtime; expose Web globals.
+  {
+    files: ["functions/**/*.{js,ts}"],
+    languageOptions: {
+      globals: {
+        URL: "readonly",
+        Response: "readonly",
+        Request: "readonly",
+        fetch: "readonly",
+      },
+    },
+  },
 );

--- a/functions/blog.js
+++ b/functions/blog.js
@@ -1,0 +1,24 @@
+// Redirects legacy /blog?year=… and /blog?tag=… to the new path-based archives.
+// Cloudflare Pages' _redirects file can't match on query strings, so this
+// runs as a Pages Function at /blog and falls through to the static
+// dist/blog/index.html when no query param is present.
+export const onRequest = async (context) => {
+  const url = new URL(context.request.url);
+  const year = url.searchParams.get("year");
+  const tag = url.searchParams.get("tag");
+
+  if (year) {
+    return Response.redirect(
+      new URL(`/blog/year/${year}`, url.origin).toString(),
+      301,
+    );
+  }
+  if (tag) {
+    return Response.redirect(
+      new URL(`/blog/tag/${tag}`, url.origin).toString(),
+      301,
+    );
+  }
+
+  return context.next();
+};

--- a/package.json
+++ b/package.json
@@ -51,6 +51,11 @@
     "prettier-plugin-astro": "^0.14.1",
     "prettier-plugin-tailwindcss": "^0.8.0",
     "typescript-eslint": "^8.59.1",
-    "wrangler": "^4.85.0"
+    "wrangler": "^4.91.0"
+  },
+  "pnpm": {
+    "onlyBuiltDependencies": [
+      "workerd"
+    ]
   }
 }

--- a/package.json
+++ b/package.json
@@ -28,7 +28,6 @@
     "@tailwindcss/vite": "^4.2.4",
     "astro": "^6.1.9",
     "dayjs": "^1.11.20",
-    "nuqs": "^2.8.9",
     "react": "^19.2.5",
     "react-dom": "^19.2.5",
     "tailwind-merge": "^3.5.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -44,9 +44,6 @@ importers:
       dayjs:
         specifier: ^1.11.20
         version: 1.11.20
-      nuqs:
-        specifier: ^2.8.9
-        version: 2.8.9(react@19.2.5)
       react:
         specifier: ^19.2.5
         version: 19.2.5
@@ -983,9 +980,6 @@ packages:
 
   '@speed-highlight/core@1.2.14':
     resolution: {integrity: sha512-G4ewlBNhUtlLvrJTb88d2mdy2KRijzs4UhnlrOSRT4bmjh/IqNElZa3zkrZ+TC47TwtlDWzVLFADljF1Ijp5hA==}
-
-  '@standard-schema/spec@1.0.0':
-    resolution: {integrity: sha512-m2bOd0f2RT9k8QJx1JN85cZYyH1RqFBdlwtkSlf4tBDYLCiiZnv1fIIwacK6cqwXavOydf0NPToMQgpKq+dVlA==}
 
   '@tailwindcss/forms@0.5.11':
     resolution: {integrity: sha512-h9wegbZDPurxG22xZSoWtdzc41/OlNEUQERNqI/0fOwa2aVlWGu7C35E/x6LDyD3lgtztFSSjKZyuVM0hxhbgA==}
@@ -2458,27 +2452,6 @@ packages:
 
   nth-check@2.1.1:
     resolution: {integrity: sha512-lqjrjmaOoAnWfMmBPL+XNnynZh2+swxiX3WUE0s4yEHI6m+AwrK2UZOimIRl3X/4QctVqS8AiZjFqyOGrMXb/w==}
-
-  nuqs@2.8.9:
-    resolution: {integrity: sha512-8ou6AEwsxMWSYo2qkfZtYFVzngwbKmg4c00HVxC1fF6CEJv3Fwm6eoZmfVPALB+vw8Udo7KL5uy96PFcYe1BIQ==}
-    peerDependencies:
-      '@remix-run/react': '>=2'
-      '@tanstack/react-router': ^1
-      next: '>=14.2.0'
-      react: '>=18.2.0 || ^19.0.0-0'
-      react-router: ^5 || ^6 || ^7
-      react-router-dom: ^5 || ^6 || ^7
-    peerDependenciesMeta:
-      '@remix-run/react':
-        optional: true
-      '@tanstack/react-router':
-        optional: true
-      next:
-        optional: true
-      react-router:
-        optional: true
-      react-router-dom:
-        optional: true
 
   obug@2.1.1:
     resolution: {integrity: sha512-uTqF9MuPraAQ+IsnPf366RG4cP9RtUi7MLO1N3KEc+wb0a6yKpeL0lmk2IB1jY5KHPAlTc6T/JRdC/YqxHNwkQ==}
@@ -4252,8 +4225,6 @@ snapshots:
   '@sindresorhus/is@7.2.0': {}
 
   '@speed-highlight/core@1.2.14': {}
-
-  '@standard-schema/spec@1.0.0': {}
 
   '@tailwindcss/forms@0.5.11(tailwindcss@4.2.4)':
     dependencies:
@@ -6153,11 +6124,6 @@ snapshots:
   nth-check@2.1.1:
     dependencies:
       boolbase: 1.0.0
-
-  nuqs@2.8.9(react@19.2.5):
-    dependencies:
-      '@standard-schema/spec': 1.0.0
-      react: 19.2.5
 
   obug@2.1.1: {}
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -109,8 +109,8 @@ importers:
         specifier: ^8.59.1
         version: 8.59.1(eslint@10.2.1(jiti@2.6.1))(typescript@6.0.3)
       wrangler:
-        specifier: ^4.85.0
-        version: 4.85.0
+        specifier: ^4.91.0
+        version: 4.91.0
 
 packages:
 
@@ -330,9 +330,9 @@ packages:
   '@clack/prompts@1.2.0':
     resolution: {integrity: sha512-4jmztR9fMqPMjz6H/UZXj0zEmE43ha1euENwkckKKel4XpSfokExPo5AiVStdHSAlHekz4d0CA/r45Ok1E4D3w==}
 
-  '@cloudflare/kv-asset-handler@0.4.2':
-    resolution: {integrity: sha512-SIOD2DxrRRwQ+jgzlXCqoEFiKOFqaPjhnNTGKXSRLvp1HiOvapLaFG2kEr9dYQTYe8rKrd9uvDUzmAITeNyaHQ==}
-    engines: {node: '>=18.0.0'}
+  '@cloudflare/kv-asset-handler@0.5.0':
+    resolution: {integrity: sha512-jxQYkj8dSIzc0cD6cMMNdOc1UVjqSqu8BZdor5s8cGjW2I8BjODt/kWPVdY+u9zj3ms75Q5qaZgnxUad83+eAg==}
+    engines: {node: '>=22.0.0'}
 
   '@cloudflare/unenv-preset@2.16.1':
     resolution: {integrity: sha512-ECxObrMfyTl5bhQf/lZCXwo5G6xX9IAUo+nDMKK4SZ8m4Jvvxp52vilxyySSWh2YTZz8+HQ07qGH/2rEom1vDw==}
@@ -343,32 +343,32 @@ packages:
       workerd:
         optional: true
 
-  '@cloudflare/workerd-darwin-64@1.20260424.1':
-    resolution: {integrity: sha512-yFR1XaJbSDLg/qbwtrYaU2xwFXatIPKR5nrMQCN1q/m6+Qe/j6r+kCnFEvOJjMZOm9iCKsE6Qly5clgl4u32qw==}
+  '@cloudflare/workerd-darwin-64@1.20260511.1':
+    resolution: {integrity: sha512-xQXYe0ILEGKyFFgZ9SlxZV2RkWXxp9mIA5mlqfdEmmSInMHlWRO4H/l6oCXZnQXNH6o3bvmGuNzl6Mac5+Omgg==}
     engines: {node: '>=16'}
     cpu: [x64]
     os: [darwin]
 
-  '@cloudflare/workerd-darwin-arm64@1.20260424.1':
-    resolution: {integrity: sha512-LqWKcE7x/9KyC2iQvKPeb20hKST3dYXDZlYTvFymgR1DfLS0OFOCzVGTloVNd7WqvK4SkdzBYfxo7QMIAeBK0w==}
+  '@cloudflare/workerd-darwin-arm64@1.20260511.1':
+    resolution: {integrity: sha512-QOaY4/BlQfDEZgTlrwCPreRIyenYmFWREVP79SSz6K6QBf7bf8ubaATN11NZbouEg19iTMtl5L7FLYdcz1tz7g==}
     engines: {node: '>=16'}
     cpu: [arm64]
     os: [darwin]
 
-  '@cloudflare/workerd-linux-64@1.20260424.1':
-    resolution: {integrity: sha512-YlEBFbAYZHe/ylzl8WEYQEU/jr+0XMqXaST2oBk5oVjksdb1NGuJaggluCdZAzuJJ8UqdTmyhY5u/qrasbiFWA==}
+  '@cloudflare/workerd-linux-64@1.20260511.1':
+    resolution: {integrity: sha512-5ZV6SHjU7WSsb9pRPSssckLJgDI5xemv7XpKWM023hMv9Q3jb4ZpkZEeIOGt2Q46E4/fcxfnXeQbL1nukDIpLg==}
     engines: {node: '>=16'}
     cpu: [x64]
     os: [linux]
 
-  '@cloudflare/workerd-linux-arm64@1.20260424.1':
-    resolution: {integrity: sha512-qJ0X0m6cL8fWDUPDg8K4IxYZXNJI6XbeOihqjnqKbAClrjdPDn8VUSd+z2XiCQ5NylMtMrpa/skC9UfaR6mh8g==}
+  '@cloudflare/workerd-linux-arm64@1.20260511.1':
+    resolution: {integrity: sha512-BG8rVZZCqTvnwOMPuh+cjt/VbZ3QchxXaBOlfromw+zLQoblSHJorMPZ/JY4/phV7RoP8gB2C84bBPcahvZUnQ==}
     engines: {node: '>=16'}
     cpu: [arm64]
     os: [linux]
 
-  '@cloudflare/workerd-windows-64@1.20260424.1':
-    resolution: {integrity: sha512-tZ7Z9qmYNAP6z1/+8r/zKbk8F8DZmpmwNzMeN+zkde2Wnhfr3FBqOkJXT/5zmli8HPoWrIXxSiyqcNDMy8V2Zg==}
+  '@cloudflare/workerd-windows-64@1.20260511.1':
+    resolution: {integrity: sha512-tGEyfKFArBL0NdqmABqzsIK1vmHdshkdFzCAUo1j6LqYsEpgJWCzvqwX9IpNHEc/AAm0UtPOLhLKhz1DA7HQLA==}
     engines: {node: '>=16'}
     cpu: [x64]
     os: [win32]
@@ -2394,9 +2394,9 @@ packages:
     resolution: {integrity: sha512-r9deDe9p5FJUPZAk3A59wGH7Ii9YrjjWw0jmw/liSbHl2CHiyXj6FcDXDu2K3TjVAXqiJdaw3xxwlZZr9E6nHg==}
     hasBin: true
 
-  miniflare@4.20260424.0:
-    resolution: {integrity: sha512-B6MKBBd5TJ19daUc3Ae9rWctn1nDA/VCXykXfCsp9fTxyfGxnZY27tJs1caxgE9MWEMMKGbGHouqVtgKbKGxmw==}
-    engines: {node: '>=18.0.0'}
+  miniflare@4.20260511.0:
+    resolution: {integrity: sha512-GjTfjtdrDb4LTUcA1S/iz/YKMvSxlbgAfgXpyhM1PQV/xzUYRpKWayq3R1vOQg53Y/g0epaBFaZLA2QbnS/meA==}
+    engines: {node: '>=22.0.0'}
     hasBin: true
 
   minimatch@10.2.5:
@@ -3252,17 +3252,17 @@ packages:
     resolution: {integrity: sha512-BN22B5eaMMI9UMtjrGd5g5eCYPpCPDUy0FJXbYsaT5zYxjFOckS53SQDE3pWkVoWpHXVb3BrYcEN4Twa55B5cA==}
     engines: {node: '>=0.10.0'}
 
-  workerd@1.20260424.1:
-    resolution: {integrity: sha512-oKsB0Xo/mfkYMdSACoS06XZg09VUK4rXwHfF/1t3P++sMbwzf4UHQvMO57+zxpEB2nVrY/ZkW0bYFGq4GdAFSQ==}
+  workerd@1.20260511.1:
+    resolution: {integrity: sha512-ecODCw4iWIuvuXdfy358zNpGPuO8k2WLMTaM1TKd+DuR6IF/oItVuvjf4BNhiKXlhIYBbD5GQ0gGHBY/IxSJVA==}
     engines: {node: '>=16'}
     hasBin: true
 
-  wrangler@4.85.0:
-    resolution: {integrity: sha512-93cwt2RPb1qdcmEgPzH7ybiLN4BIKoWpscIX6SywjHrQOeIZrQk2haoc3XMLKtQTmzapxza9OuDD+kMHpsuuhg==}
-    engines: {node: '>=20.3.0'}
+  wrangler@4.91.0:
+    resolution: {integrity: sha512-dFzhAd2/DpaHGRrQMQkL8F6AKmjzK2hfbhyTJ+5dcZS6jdl9KG8oxO5oAflIdlsRYnrOzxRxQnvIqwewIq1FXA==}
+    engines: {node: '>=22.0.0'}
     hasBin: true
     peerDependencies:
-      '@cloudflare/workers-types': ^4.20260424.1
+      '@cloudflare/workers-types': ^4.20260511.1
     peerDependenciesMeta:
       '@cloudflare/workers-types':
         optional: true
@@ -3720,27 +3720,27 @@ snapshots:
       fast-wrap-ansi: 0.1.6
       sisteransi: 1.0.5
 
-  '@cloudflare/kv-asset-handler@0.4.2': {}
+  '@cloudflare/kv-asset-handler@0.5.0': {}
 
-  '@cloudflare/unenv-preset@2.16.1(unenv@2.0.0-rc.24)(workerd@1.20260424.1)':
+  '@cloudflare/unenv-preset@2.16.1(unenv@2.0.0-rc.24)(workerd@1.20260511.1)':
     dependencies:
       unenv: 2.0.0-rc.24
     optionalDependencies:
-      workerd: 1.20260424.1
+      workerd: 1.20260511.1
 
-  '@cloudflare/workerd-darwin-64@1.20260424.1':
+  '@cloudflare/workerd-darwin-64@1.20260511.1':
     optional: true
 
-  '@cloudflare/workerd-darwin-arm64@1.20260424.1':
+  '@cloudflare/workerd-darwin-arm64@1.20260511.1':
     optional: true
 
-  '@cloudflare/workerd-linux-64@1.20260424.1':
+  '@cloudflare/workerd-linux-64@1.20260511.1':
     optional: true
 
-  '@cloudflare/workerd-linux-arm64@1.20260424.1':
+  '@cloudflare/workerd-linux-arm64@1.20260511.1':
     optional: true
 
-  '@cloudflare/workerd-windows-64@1.20260424.1':
+  '@cloudflare/workerd-windows-64@1.20260511.1':
     optional: true
 
   '@cspotcode/source-map-support@0.8.1':
@@ -6075,12 +6075,12 @@ snapshots:
 
   mini-svg-data-uri@1.4.4: {}
 
-  miniflare@4.20260424.0:
+  miniflare@4.20260511.0:
     dependencies:
       '@cspotcode/source-map-support': 0.8.1
       sharp: 0.34.5
       undici: 7.24.8
-      workerd: 1.20260424.1
+      workerd: 1.20260511.1
       ws: 8.18.0
       youch: 4.1.0-beta.10
     transitivePeerDependencies:
@@ -6931,24 +6931,24 @@ snapshots:
 
   word-wrap@1.2.5: {}
 
-  workerd@1.20260424.1:
+  workerd@1.20260511.1:
     optionalDependencies:
-      '@cloudflare/workerd-darwin-64': 1.20260424.1
-      '@cloudflare/workerd-darwin-arm64': 1.20260424.1
-      '@cloudflare/workerd-linux-64': 1.20260424.1
-      '@cloudflare/workerd-linux-arm64': 1.20260424.1
-      '@cloudflare/workerd-windows-64': 1.20260424.1
+      '@cloudflare/workerd-darwin-64': 1.20260511.1
+      '@cloudflare/workerd-darwin-arm64': 1.20260511.1
+      '@cloudflare/workerd-linux-64': 1.20260511.1
+      '@cloudflare/workerd-linux-arm64': 1.20260511.1
+      '@cloudflare/workerd-windows-64': 1.20260511.1
 
-  wrangler@4.85.0:
+  wrangler@4.91.0:
     dependencies:
-      '@cloudflare/kv-asset-handler': 0.4.2
-      '@cloudflare/unenv-preset': 2.16.1(unenv@2.0.0-rc.24)(workerd@1.20260424.1)
+      '@cloudflare/kv-asset-handler': 0.5.0
+      '@cloudflare/unenv-preset': 2.16.1(unenv@2.0.0-rc.24)(workerd@1.20260511.1)
       blake3-wasm: 2.1.5
       esbuild: 0.27.3
-      miniflare: 4.20260424.0
+      miniflare: 4.20260511.0
       path-to-regexp: 6.3.0
       unenv: 2.0.0-rc.24
-      workerd: 1.20260424.1
+      workerd: 1.20260511.1
     optionalDependencies:
       fsevents: 2.3.3
     transitivePeerDependencies:

--- a/public/_redirects
+++ b/public/_redirects
@@ -1,2 +1,0 @@
-/blog?year=:y    /blog/year/:y    301
-/blog?tag=:t     /blog/tag/:t     301

--- a/public/_redirects
+++ b/public/_redirects
@@ -1,0 +1,2 @@
+/blog?year=:y    /blog/year/:y    301
+/blog?tag=:t     /blog/tag/:t     301

--- a/src/components/BaseHead.astro
+++ b/src/components/BaseHead.astro
@@ -8,15 +8,20 @@ interface Props {
   title?: string;
   description?: string;
   image?: string;
+  canonicalURL?: string | URL;
 }
-
-const canonicalURL = new URL(Astro.url.pathname, Astro.site);
 
 const {
   title = SITE_TITLE,
   description = SITE_DESCRIPTION,
   image = SITE_IMAGE,
+  canonicalURL: canonicalURLProp,
 } = Astro.props;
+
+const canonicalURL =
+  canonicalURLProp != null
+    ? new URL(canonicalURLProp, Astro.site)
+    : new URL(Astro.url.pathname, Astro.site);
 ---
 
 <!-- Global Metadata -->
@@ -51,7 +56,7 @@ const {
 
 <!-- Open Graph / Facebook -->
 <meta property="og:type" content="website" />
-<meta property="og:url" content={Astro.url} />
+<meta property="og:url" content={canonicalURL} />
 <meta property="og:title" content={title} />
 <meta property="og:description" content={description} />
 <meta property="og:image" content={new URL(image, Astro.url)} />
@@ -60,7 +65,7 @@ const {
 
 <!-- Twitter -->
 <meta property="twitter:card" content="summary_large_image" />
-<meta property="twitter:url" content={Astro.url} />
+<meta property="twitter:url" content={canonicalURL} />
 <meta property="twitter:title" content={title} />
 <meta property="twitter:description" content={description} />
 <meta property="twitter:image" content={new URL(image, Astro.url)} />

--- a/src/components/react/components/TwBlogLayout.tsx
+++ b/src/components/react/components/TwBlogLayout.tsx
@@ -4,13 +4,13 @@ import TwBlogNav from "./TwBlogNav";
 import TwFooter from "./TwFooter";
 import TwLayout from "./TwLayout";
 import TwLink from "./TwLink";
-import type { PostListItem } from "@/libs/posts";
 
 const TwBlogLayout = (
   props: ComponentProps<"div"> & {
     tags?: string[];
     years?: string[];
-    allPosts?: PostListItem[];
+    selectedYear?: string | null;
+    selectedTag?: string | null;
     showYearsInitially?: boolean;
     showTagsInitially?: boolean;
     hideBlogNav?: boolean;
@@ -20,7 +20,8 @@ const TwBlogLayout = (
   const {
     tags = [],
     years = [],
-    allPosts = [],
+    selectedYear = null,
+    selectedTag = null,
     showYearsInitially = false,
     showTagsInitially = false,
     hideBlogNav = false,
@@ -49,7 +50,8 @@ const TwBlogLayout = (
             <TwBlogNav
               tags={tags}
               years={years}
-              allPosts={allPosts}
+              selectedYear={selectedYear}
+              selectedTag={selectedTag}
               showYearsInitially={showYearsInitially}
               showTagsInitially={showTagsInitially}
             />

--- a/src/components/react/components/TwBlogNav.tsx
+++ b/src/components/react/components/TwBlogNav.tsx
@@ -1,8 +1,5 @@
-import { useQueryState } from "nuqs";
 import React, { type ComponentProps, useState } from "react";
 import { twMerge } from "tailwind-merge";
-import type { PostListItem } from "@/libs/posts";
-import { findLatestYearWithPosts } from "@/libs/sharedUtils";
 
 export const TwBlogNavButton = ({
   className,
@@ -19,32 +16,40 @@ export const TwBlogNavButton = ({
   />
 );
 
+const TwBlogNavLink = ({
+  className,
+  selected,
+  ...restProps
+}: ComponentProps<"a"> & { selected?: boolean }) => (
+  <a
+    {...restProps}
+    className={twMerge(
+      "text-sky-500 hover:text-sky-700 dark:text-sky-400 hover:dark:text-sky-200",
+      className,
+      selected && "font-semibold underline underline-offset-2",
+    )}
+  />
+);
+
 const TwBlogNav = ({
   tags,
   years,
-  allPosts,
+  selectedYear,
+  selectedTag,
   showYearsInitially = false,
   showTagsInitially = false,
 }: {
   tags: string[];
   years: string[];
-  allPosts: PostListItem[];
+  selectedYear: string | null;
+  selectedTag: string | null;
   showYearsInitially?: boolean;
   showTagsInitially?: boolean;
 }) => {
   const [showTags, setShowTags] = useState<boolean>(showTagsInitially);
-  const [showYears, setShowYears] = useState<boolean>(showYearsInitially);
-
-  const [selectedTag, setSelectedTag] = useQueryState("tag");
-  const [selectedYear, setSelectedYear] = useQueryState("year");
-
-  // Set default navigation state - always show years if nothing is showing
-  React.useEffect(() => {
-    if (!showTags && !showYears) {
-      // eslint-disable-next-line react-hooks/set-state-in-effect
-      setShowYears(true);
-    }
-  }, [showTags, showYears]);
+  const [showYears, setShowYears] = useState<boolean>(
+    showYearsInitially || (!showTagsInitially && !showYearsInitially),
+  );
 
   return (
     <nav className="mb-4 flex flex-col">
@@ -91,67 +96,24 @@ const TwBlogNav = ({
           {showYears &&
             years.map((year, ind) => (
               <React.Fragment key={year}>
-                <TwBlogNavButton
-                  onClick={() => {
-                    // more interactiveness on the blog page
-                    if (window.location.pathname === "/blog") {
-                      if (year === selectedYear) {
-                        // If clicking the same year, go to latest year instead of clearing
-                        const latestYear = findLatestYearWithPosts(
-                          years,
-                          allPosts,
-                        );
-                        setSelectedYear(latestYear);
-                      } else {
-                        // If clicking different year, select it
-                        setSelectedYear(year);
-                      }
-
-                      // Clear tag selection when selecting a year
-                      setSelectedTag(null);
-                    } else {
-                      window.location.href = `/blog?year=${year}`;
-                    }
-                  }}
+                <TwBlogNavLink
+                  href={`/blog/year/${year}`}
                   selected={selectedYear === year}
                 >
                   {year}
-                </TwBlogNavButton>
+                </TwBlogNavLink>
                 {ind !== years.length - 1 && <span>•</span>}
               </React.Fragment>
             ))}
           {showTags &&
             tags.map((tag, ind) => (
               <React.Fragment key={tag}>
-                <TwBlogNavButton
-                  onClick={() => {
-                    // more interactiveness on the blog page
-                    if (window.location.pathname === "/blog") {
-                      if (tag === selectedTag) {
-                        // If clicking the same tag, go to latest year instead of clearing
-                        const latestYear = findLatestYearWithPosts(
-                          years,
-                          allPosts,
-                        );
-                        setSelectedYear(latestYear);
-                        setSelectedTag(null);
-                        // Hide tags and show years
-                        setShowYears(true);
-                        setShowTags(false);
-                      } else {
-                        // If clicking different tag, select it
-                        setSelectedTag(tag);
-                        // Clear year selection when selecting a tag
-                        setSelectedYear(null);
-                      }
-                    } else {
-                      window.location.href = `/blog?tag=${tag}`;
-                    }
-                  }}
+                <TwBlogNavLink
+                  href={`/blog/tag/${tag}`}
                   selected={selectedTag === tag}
                 >
                   {tag}
-                </TwBlogNavButton>
+                </TwBlogNavLink>
                 {ind !== tags.length - 1 && <span>•</span>}
               </React.Fragment>
             ))}

--- a/src/components/react/pages/blog.tsx
+++ b/src/components/react/pages/blog.tsx
@@ -1,81 +1,30 @@
-import { useQueryState } from "nuqs";
-import { NuqsAdapter } from "nuqs/adapters/react";
-import { useEffect, useState } from "react";
 import TwBlogLayout from "@/components/react/components/TwBlogLayout";
 import TwBlogListItem from "@/components/react/components/TwBlogListItem";
 import type { PostListItem } from "@/libs/posts";
-import { findLatestYearWithPosts } from "@/libs/sharedUtils";
 
 interface BlogProps {
-  allPosts: PostListItem[];
+  filteredPosts: PostListItem[];
   tags: string[];
   years: string[];
+  selectedYear: string | null;
+  selectedTag: string | null;
 }
 
-const Blog = ({ allPosts, tags, years }: BlogProps) => {
-  const [filteredPosts, setFilteredPosts] = useState<PostListItem[]>([]);
-  const [isInitialized, setIsInitialized] = useState(false);
-  const [queryTag] = useQueryState("tag");
-  const [queryYear, setQueryYear] = useQueryState("year");
-
-  // Initialize with latest year if no query params
-  useEffect(() => {
-    if (!queryTag && !queryYear && !isInitialized) {
-      const latestYear = findLatestYearWithPosts(years, allPosts);
-      setQueryYear(latestYear);
-      // eslint-disable-next-line react-hooks/set-state-in-effect
-      setIsInitialized(true);
-    } else if ((queryTag || queryYear) && !isInitialized) {
-      setIsInitialized(true);
-    }
-  }, [queryTag, queryYear, years, allPosts, isInitialized, setQueryYear]);
-
-  // Filter posts based on query params
-  useEffect(() => {
-    if (!isInitialized) {
-      // eslint-disable-next-line react-hooks/set-state-in-effect
-      setFilteredPosts([]); // Keep empty until initialized
-      return;
-    }
-
-    if (!queryTag && !queryYear) {
-      setFilteredPosts(allPosts);
-      return;
-    }
-
-    // We don't support this scenario anymore
-    if (queryTag && queryYear) {
-      const filtered = allPosts.filter((post) => {
-        return post.tags?.includes(queryTag) && post.year === queryYear;
-      });
-      setFilteredPosts(filtered);
-      return;
-    }
-
-    if (queryTag) {
-      const filtered = allPosts.filter((post) => {
-        return post.tags?.includes(queryTag);
-      });
-      setFilteredPosts(filtered);
-      return;
-    }
-
-    if (queryYear) {
-      const filtered = allPosts.filter((post) => {
-        return post.year === queryYear;
-      });
-      setFilteredPosts(filtered);
-      return;
-    }
-  }, [queryTag, queryYear, allPosts, isInitialized]);
-
+const Blog = ({
+  filteredPosts,
+  tags,
+  years,
+  selectedYear,
+  selectedTag,
+}: BlogProps) => {
   return (
     <TwBlogLayout
       tags={tags}
       years={years}
-      allPosts={allPosts}
-      showYearsInitially={!!queryYear && !queryTag}
-      showTagsInitially={!!queryTag && !queryYear}
+      selectedYear={selectedYear}
+      selectedTag={selectedTag}
+      showYearsInitially={!selectedTag}
+      showTagsInitially={!!selectedTag}
     >
       {/* posts list */}
       <div className="flex flex-col items-start gap-6">
@@ -87,12 +36,4 @@ const Blog = ({ allPosts, tags, years }: BlogProps) => {
   );
 };
 
-const BlogWrapper = ({ allPosts, tags, years }: BlogProps) => {
-  return (
-    <NuqsAdapter>
-      <Blog allPosts={allPosts} tags={tags} years={years} />
-    </NuqsAdapter>
-  );
-};
-
-export default BlogWrapper;
+export default Blog;

--- a/src/components/react/pages/post.tsx
+++ b/src/components/react/pages/post.tsx
@@ -1,4 +1,3 @@
-import { NuqsAdapter } from "nuqs/adapters/react";
 import type { ReactNode } from "react";
 import { twMerge } from "tailwind-merge";
 import TwBlogLayout from "@/components/react/components/TwBlogLayout";
@@ -61,12 +60,4 @@ const Post = ({ postData, children }: PostProps) => {
   );
 };
 
-const PostWrapper = ({ postData, children }: PostProps) => {
-  return (
-    <NuqsAdapter>
-      <Post postData={postData}>{children}</Post>
-    </NuqsAdapter>
-  );
-};
-
-export default PostWrapper;
+export default Post;

--- a/src/pages/blog/tag/[tag].astro
+++ b/src/pages/blog/tag/[tag].astro
@@ -5,7 +5,13 @@ import Blog from "@/components/react/pages/blog";
 import ThemeButton from "@/components/ThemeButton.astro";
 import { getAllTagsAndYears } from "@/libs/blog";
 import { entryToPostListItem } from "@/libs/posts";
-import { findLatestYearWithPosts } from "@/libs/sharedUtils";
+
+export async function getStaticPaths() {
+  const { tags } = await getAllTagsAndYears();
+  return tags.map((tag) => ({ params: { tag } }));
+}
+
+const { tag } = Astro.params as { tag: string };
 
 const entries = await getCollection("posts");
 const allPosts = entries
@@ -13,16 +19,15 @@ const allPosts = entries
   .sort((a, b) => b.date.getTime() - a.date.getTime());
 const { tags, years } = await getAllTagsAndYears();
 
-const latestYear = findLatestYearWithPosts(years, allPosts);
-const filteredPosts = allPosts.filter((post) => post.year === latestYear);
+const filteredPosts = allPosts.filter((post) => post.tags?.includes(tag));
 ---
 
 <!doctype html>
 <html lang="en">
   <head>
     <BaseHead
-      title="bluenex's blog"
-      description="A personal blog for sharing anything that piques my interest."
+      title={`bluenex's blog — #${tag}`}
+      description={`Posts tagged with #${tag}.`}
     />
   </head>
   <body>
@@ -34,8 +39,8 @@ const filteredPosts = allPosts.filter((post) => post.year === latestYear);
       filteredPosts={filteredPosts}
       tags={tags}
       years={years}
-      selectedYear={latestYear}
-      selectedTag={null}
+      selectedYear={null}
+      selectedTag={tag}
       client:load
     />
   </body>

--- a/src/pages/blog/year/[year].astro
+++ b/src/pages/blog/year/[year].astro
@@ -7,22 +7,32 @@ import { getAllTagsAndYears } from "@/libs/blog";
 import { entryToPostListItem } from "@/libs/posts";
 import { findLatestYearWithPosts } from "@/libs/sharedUtils";
 
+export async function getStaticPaths() {
+  const { years } = await getAllTagsAndYears();
+  return years.map((year) => ({ params: { year } }));
+}
+
+const { year } = Astro.params as { year: string };
+
 const entries = await getCollection("posts");
 const allPosts = entries
   .map(entryToPostListItem)
   .sort((a, b) => b.date.getTime() - a.date.getTime());
 const { tags, years } = await getAllTagsAndYears();
 
+const filteredPosts = allPosts.filter((post) => post.year === year);
 const latestYear = findLatestYearWithPosts(years, allPosts);
-const filteredPosts = allPosts.filter((post) => post.year === latestYear);
+// Latest-year archive is a duplicate of /blog; point its canonical at /blog.
+const canonicalURL = year === latestYear ? "/blog/" : undefined;
 ---
 
 <!doctype html>
 <html lang="en">
   <head>
     <BaseHead
-      title="bluenex's blog"
-      description="A personal blog for sharing anything that piques my interest."
+      title={`bluenex's blog — ${year}`}
+      description={`Posts from ${year}.`}
+      canonicalURL={canonicalURL}
     />
   </head>
   <body>
@@ -34,7 +44,7 @@ const filteredPosts = allPosts.filter((post) => post.year === latestYear);
       filteredPosts={filteredPosts}
       tags={tags}
       years={years}
-      selectedYear={latestYear}
+      selectedYear={year}
       selectedTag={null}
       client:load
     />


### PR DESCRIPTION
## Summary

- `/blog` previously sent only a React shell over the wire and filtered posts client-side via `?year=…` (nuqs). External agents WebFetching `bluenex.dev/blog` saw zero posts in the HTML.
- Replace the CSR filter with statically prerendered archives: `/blog/year/<year>` and `/blog/tag/<tag>`. `/blog` itself now renders the latest year's posts directly in the server-emitted HTML.
- Legacy `?year=`/`?tag=` URLs 301 to the new path-based form via a Cloudflare Pages Function at `functions/blog.js` (Pages' `_redirects` can't match on query strings).
- Latest-year archive (`/blog/year/<latestYear>`) declares `/blog/` as its canonical to avoid duplicate-content.
- `nuqs` dependency removed.
- `wrangler` bumped 4.85 → 4.91 (older bundled workerd didn't know today's compatibility date) and `pnpm.onlyBuiltDependencies` opts workerd's postinstall in so `preview:wrangler` actually starts.

## Test plan

- [x] `pnpm run build` — 44 pages, including 7 `/blog/year/*` and 14 `/blog/tag/*`.
- [x] `pnpm run checktype` clean.
- [x] `pnpm run lint` clean.
- [x] `curl -sL http://localhost:8788/blog | grep '<h3'` — returns 2025 post titles in raw HTML (no JS).
- [x] `curl -sL http://localhost:8788/blog/year/2022` — only 2022 post titles in raw HTML.
- [x] `curl -sL http://localhost:8788/blog/tag/git` — only git-tagged post titles in raw HTML.
- [x] `curl -sI 'http://localhost:8788/blog?year=2017'` — 301 to `/blog/year/2017`.
- [x] Manual click-through in browser: years/tags toggle still works, selected state highlights, no console errors.
- [x] Deploy preview on Cloudflare Pages: confirm the Function picks up legacy `?year=`/`?tag=` URLs in production too.

🤖 Generated with [Claude Code](https://claude.com/claude-code)